### PR TITLE
Fix PR Description Formatting

### DIFF
--- a/src/ai-client.ts
+++ b/src/ai-client.ts
@@ -19,6 +19,39 @@ const MAX_RETRIES = 3;
 const RETRY_BASE_MS = 1000;
 
 /**
+ * Normalizes indentation by removing common leading whitespace from all lines.
+ * This prevents XML indentation from being interpreted as code blocks in markdown.
+ */
+function normalizeIndentation(text: string): string {
+  const lines = text.split("\n");
+
+  // Find non-empty lines to calculate minimum indentation
+  const nonEmptyLines = lines.filter((line) => line.trim().length > 0);
+
+  if (nonEmptyLines.length === 0) {
+    return text.trim();
+  }
+
+  // Find the minimum indentation among non-empty lines
+  const minIndent = Math.min(
+    ...nonEmptyLines.map((line) => {
+      const match = line.match(/^[ \t]*/);
+      return match ? match[0].length : 0;
+    }),
+  );
+
+  // Remove the minimum indentation from all lines
+  const normalizedLines = lines.map((line) => {
+    if (line.trim().length === 0) {
+      return ""; // Keep empty lines empty
+    }
+    return line.slice(minIndent);
+  });
+
+  return normalizedLines.join("\n").trim();
+}
+
+/**
  * Executes a function with retry logic.
  */
 export async function callWithRetry<T>(
@@ -208,7 +241,7 @@ function parseSummaryResponse(text: string): DiffSummary {
       /<prDescription>(.*?)<\/prDescription>/s,
     );
     const prDescription = prDescriptionMatch
-      ? prDescriptionMatch[1].trim()
+      ? normalizeIndentation(prDescriptionMatch[1])
       : undefined;
 
     // Extract hunks

--- a/src/ai-client.ts
+++ b/src/ai-client.ts
@@ -22,7 +22,7 @@ const RETRY_BASE_MS = 1000;
  * Normalizes indentation by removing common leading whitespace from all lines.
  * This prevents XML indentation from being interpreted as code blocks in markdown.
  */
-function normalizeIndentation(text: string): string {
+export function normalizeIndentation(text: string): string {
   const lines = text.split("\n");
 
   // Find non-empty lines to calculate minimum indentation

--- a/test/ai-client.test.ts
+++ b/test/ai-client.test.ts
@@ -260,16 +260,16 @@ describe("AI Client", () => {
 
       expect(result.prDescription).toBe(`## Add User Authentication Service
 
-    This PR introduces a new authentication service for user login and session management.
+This PR introduces a new authentication service for user login and session management.
 
-    **Key Changes:**
-    - Added AuthService class with JWT token handling
-    - Integrated authentication middleware for protected routes
-    - Added user session management and logout functionality
+**Key Changes:**
+- Added AuthService class with JWT token handling
+- Integrated authentication middleware for protected routes
+- Added user session management and logout functionality
 
-    **Review Notes:**
-    - Please verify the JWT token validation logic
-    - Ensure proper error handling for invalid credentials`);
+**Review Notes:**
+- Please verify the JWT token validation logic
+- Ensure proper error handling for invalid credentials`);
 
       expect(result.prType).toBe("feature");
       expect(result.decision).toEqual({


### PR DESCRIPTION
## Normalize PR description indentation

This PR adds a helper to remove common leading whitespace from multiline text and applies it to the extracted PR description, ensuring Markdown renders correctly without unintended code blocks.

**Key Changes:**
- Added `normalizeIndentation` function in `ai-client.ts`
- Replaced `trim` with `normalizeIndentation` on `prDescription`
- Updated existing test to match normalized output

**Review Notes:**
- Verify helper behavior on edge cases (empty lines, mixed indentation)
- Ensure no regression in other text extraction logic