### PR TITLE
less nits

### DIFF
--- a/.github/workflows/codepress-review.yml
+++ b/.github/workflows/codepress-review.yml
@@ -2,7 +2,7 @@ name: CodePress Review
 
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, review_requested]
   issue_comment:
     types: [created]
   workflow_dispatch: # Allow manual triggering
@@ -15,15 +15,6 @@ permissions:
 jobs:
   ai-review:
     runs-on: ubuntu-latest
-    # Run on: PR events, manual triggers, or PR comments containing '@codepress/review'
-    if: |
-      github.event_name == 'pull_request' ||
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '@codepress/review')
-      )
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -50,7 +41,7 @@ jobs:
         run: pnpm run build
 
       - name: CodePress Review
-        uses: ./ # When published, this would be: uses: @quantfive/codepress-review@v1
+        uses: ./ # When published, this would be: uses: @quantfive/codepress-review@v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           model_provider: "openai"
@@ -59,3 +50,10 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           debug: true
+          # All trigger configurations use sensible defaults:
+          # - run_on_pr_opened: true
+          # - run_on_pr_reopened: true
+          # - run_on_review_requested: true (github-actions[bot] only)
+          # - run_on_comment_trigger: true
+          # - comment_trigger_phrase: "@codepress/review"
+          # + synchronize event runs automatically when included in workflow

--- a/README.md
+++ b/README.md
@@ -23,29 +23,29 @@ name: CodePress Review
 
 on:
   pull_request:
-    types: [opened, reopened]
-  workflow_dispatch: # Allows manual triggering from the Actions tab
+    types: [opened, reopened, review_requested] #synchronize]
+  issue_comment:
+    types: [created]
+  workflow_dispatch: # Allow manual triggering
 
 permissions:
   pull-requests: write
   contents: read
+  issues: read
 
 jobs:
   ai-review:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
       - name: CodePress Review
-        uses: quantfive/codepress-review@v2
+        uses: quantfive/codepress-review@v2 # When published
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           model_provider: "openai"
-          model_name: "gpt-4o"
+          model_name: "o4-mini"
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          # All trigger configurations use sensible defaults
+          # + synchronize event runs automatically when included in workflow
 ```
 
 ## Configuration
@@ -62,17 +62,22 @@ Add these to your repository's **Settings → Secrets and variables → Actions*
 
 ### Input Parameters
 
-| Input                   | Required | Default               | Description                                  |
-| ----------------------- | -------- | --------------------- | -------------------------------------------- |
-| `github_token`          | ✅       | `${{ github.token }}` | GitHub token for API access                  |
-| `model_provider`        | ✅       | `openai`              | AI provider: `openai`, `anthropic`, `gemini` |
-| `model_name`            | ✅       | `gpt-4o`              | Model name (see examples below)              |
-| `openai_api_key`        | ⚠️       |                       | Required if using OpenAI                     |
-| `anthropic_api_key`     | ⚠️       |                       | Required if using Anthropic                  |
-| `gemini_api_key`        | ⚠️       |                       | Required if using Google                     |
-| `max_turns`             | ❌       | `12`                  | Maximum turns for interactive agent review   |
-| `update_pr_description` | ❌       | `true`                | Auto-generate PR descriptions for blank PRs  |
-| `debug`                 | ❌       | `false`               | Enable debug mode for detailed console logs  |
+| Input                     | Required | Default               | Description                                                  |
+| ------------------------- | -------- | --------------------- | ------------------------------------------------------------ |
+| `github_token`            | ✅       | `${{ github.token }}` | GitHub token for API access                                  |
+| `model_provider`          | ✅       | `openai`              | AI provider: `openai`, `anthropic`, `gemini`                 |
+| `model_name`              | ✅       | `gpt-4o`              | Model name (see examples below)                              |
+| `openai_api_key`          | ⚠️       |                       | Required if using OpenAI                                     |
+| `anthropic_api_key`       | ⚠️       |                       | Required if using Anthropic                                  |
+| `gemini_api_key`          | ⚠️       |                       | Required if using Google                                     |
+| `max_turns`               | ❌       | `12`                  | Maximum turns for interactive agent review                   |
+| `update_pr_description`   | ❌       | `true`                | Auto-generate PR descriptions for blank PRs                  |
+| `debug`                   | ❌       | `false`               | Enable debug mode for detailed console logs                  |
+| `run_on_pr_opened`        | ❌       | `true`                | Run review when PR is opened                                 |
+| `run_on_pr_reopened`      | ❌       | `true`                | Run review when PR is reopened                               |
+| `run_on_review_requested` | ❌       | `true`                | Run review when re-review requested from github-actions[bot] |
+| `run_on_comment_trigger`  | ❌       | `true`                | Run review when comments contain trigger phrase              |
+| `comment_trigger_phrase`  | ❌       | `"@codepress/review"` | Phrase that triggers review in comments                      |
 
 ## Triggering Reviews
 

--- a/TRIGGER_CONFIGURATION.md
+++ b/TRIGGER_CONFIGURATION.md
@@ -1,0 +1,198 @@
+# CodePress Review - Trigger Configuration
+
+## Overview
+
+CodePress Review v2+ includes built-in trigger logic, making it much easier to configure when your AI reviews should run. Instead of maintaining complex workflow conditions, you can now simply configure the action inputs to control when reviews are triggered.
+
+## Migration from v1
+
+### Before (v1 - Complex Workflow)
+
+```yaml
+# Old approach - complex workflow logic
+jobs:
+  ai-review:
+    runs-on: ubuntu-latest
+    env:
+      IS_PR_OPENED_OR_REOPENED: ${{ github.event_name == 'pull_request' && (github.event.action == 'opened' || github.event.action == 'reopened') }}
+      IS_REVIEW_REQUESTED_FROM_BOT: ${{ github.event_name == 'pull_request' && github.event.action == 'review_requested' && github.event.requested_reviewer.login == 'github-actions[bot]' }}
+      IS_MANUAL_DISPATCH: ${{ github.event_name == 'workflow_dispatch' }}
+      IS_COMMENT_TRIGGER: ${{ github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@codepress/review') }}
+    if: |
+      ${{
+        env.IS_PR_OPENED_OR_REOPENED == 'true' ||
+        env.IS_REVIEW_REQUESTED_FROM_BOT == 'true' ||
+        env.IS_MANUAL_DISPATCH == 'true' ||
+        env.IS_COMMENT_TRIGGER == 'true'
+      }}
+    steps:
+      - uses: quantfive/codepress-review@v1
+```
+
+### After (v2+ - Simple Configuration)
+
+```yaml
+# New approach - just works with sensible defaults!
+jobs:
+  ai-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CodePress Review
+        uses: quantfive/codepress-review@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          model_provider: "openai"
+          model_name: "o4-mini"
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          # All trigger configurations use sensible defaults
+```
+
+## Configuration Options
+
+| Input                     | Description                                                     | Default               | Example         |
+| ------------------------- | --------------------------------------------------------------- | --------------------- | --------------- |
+| `run_on_pr_opened`        | Run review when PR is opened                                    | `true`                | `true`/`false`  |
+| `run_on_pr_reopened`      | Run review when PR is reopened                                  | `true`                | `true`/`false`  |
+| `run_on_review_requested` | Run review when re-review is requested from github-actions[bot] | `true`                | `true`/`false`  |
+| `run_on_comment_trigger`  | Run review when comments contain trigger phrase                 | `true`                | `true`/`false`  |
+| `comment_trigger_phrase`  | Phrase that triggers review in comments                         | `"@codepress/review"` | `"@bot review"` |
+
+## Workflow Event Requirements
+
+Your workflow must still listen to GitHub events (this is a GitHub Actions requirement), but you can now use a **simple, universal setup** that covers all possible triggers:
+
+```yaml
+# Simple universal setup - works for all configurations
+on:
+  pull_request:
+    types: [opened, reopened, review_requested, synchronize]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+```
+
+**Event Types Explained:**
+
+- `opened` - Review when PR is first created
+- `reopened` - Review when PR is reopened
+- `review_requested` - Review when re-review requested from github-actions[bot]
+- `synchronize` - Review when new commits are pushed to PR (optional - remove if you don't want reviews on every commit)
+- `issue_comment` - Review when comments contain trigger phrase
+- `workflow_dispatch` - Allow manual triggering
+
+**Why can't we eliminate this?** GitHub needs to know which events should start your workflow before it runs any code. The `on:` section is GitHub's event subscription system - without it, your workflow never starts.
+
+**The good news:** You can use the same `on:` section for any configuration. Our action handles all the smart filtering internally.
+
+## What We've Achieved vs. Alternatives
+
+### ✅ What We Built (Best Approach)
+
+```yaml
+# User's workflow - incredibly simple!
+on:
+  pull_request:
+    types: [opened, reopened, review_requested, synchronize]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+
+jobs:
+  ai-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: quantfive/codepress-review@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          model_provider: "openai"
+          model_name: "o4-mini"
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          # That's it! Everything else uses great defaults
+```
+
+### ❌ Alternative: Composite Actions (More Complex)
+
+```yaml
+# We could create a composite action, but users would still need:
+on:
+  pull_request:
+  # ... same events
+jobs:
+  ai-review:
+    uses: quantfive/codepress-review/.github/workflows/review.yml@v2
+    # This is actually more complex for users
+```
+
+### ❌ Alternative: Multiple Actions (Confusing)
+
+```yaml
+# We could create separate actions per trigger type, but then:
+- uses: quantfive/codepress-review-pr@v2 # For PR events
+- uses: quantfive/codepress-review-comment@v2 # For comments
+# This would be much worse UX
+```
+
+**Our approach is optimal** - minimal workflow complexity with maximum flexibility through action inputs.
+
+## Common Configurations
+
+### Conservative (Default)
+
+Only run on PR events and manual comment triggers:
+
+```yaml
+run_on_pr_opened: true
+run_on_pr_reopened: true
+run_on_review_requested: true
+run_on_comment_trigger: true
+```
+
+### Review on Every Commit
+
+Add `synchronize` to your workflow events to review every commit:
+
+```yaml
+# In your workflow's on: section
+pull_request:
+  types: [opened, reopened, review_requested, synchronize]
+```
+
+### Comment-Only
+
+Only run when explicitly requested:
+
+```yaml
+run_on_pr_opened: false
+run_on_pr_reopened: false
+run_on_review_requested: true
+run_on_comment_trigger: true
+```
+
+## How It Works
+
+1. **Event Capture**: Your workflow listens to GitHub events as usual
+2. **Smart Filtering**: The action internally checks the event details against your configuration
+3. **Early Exit**: If the current event doesn't match your trigger settings, the action exits gracefully with a log message
+4. **Execution**: If the event matches, the action proceeds with the AI review
+
+## Benefits
+
+- ✅ **Simpler workflows** - No complex conditions in YAML
+- ✅ **Centralized logic** - All trigger logic is maintained in the action
+- ✅ **Easy updates** - Action updates automatically improve trigger logic
+- ✅ **Clear configuration** - Self-documenting input parameters
+- ✅ **Flexible** - Easy to enable/disable specific triggers
+
+## Debug Mode
+
+Enable debug mode to see detailed logs about trigger decisions:
+
+```yaml
+debug: true
+```
+
+This will log messages like:
+
+- `"Running review: PR was opened"`
+- `"Skipping review: PR opened trigger is disabled"`
+- `"Running review: Comment contains trigger phrase: @codepress/review"`

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,32 @@ inputs:
     required: false
     default: "false"
 
+  # Trigger configuration inputs
+  run_on_pr_opened:
+    description: "Run review when PR is opened (true/false)"
+    required: false
+    default: "true"
+
+  run_on_pr_reopened:
+    description: "Run review when PR is reopened (true/false)"
+    required: false
+    default: "true"
+
+  run_on_review_requested:
+    description: "Run review when re-review is requested from github-actions[bot] (true/false)"
+    required: false
+    default: "true"
+
+  run_on_comment_trigger:
+    description: "Run review when comments contain trigger phrase (true/false)"
+    required: false
+    default: "true"
+
+  comment_trigger_phrase:
+    description: "Phrase that triggers review in comments (e.g., '@codepress/review')"
+    required: false
+    default: "@codepress/review"
+
 runs:
   using: "node20"
   main: "dist/index.js"

--- a/src/agent/agent-system-prompt.ts
+++ b/src/agent/agent-system-prompt.ts
@@ -26,9 +26,9 @@ const DEFAULT_REVIEW_GUIDELINES = `
     <everyLine>Read every human-written line you're responsible for. Skim only generated or data blobs.</everyLine>
     <partialContext>CRITICAL: You only see partial file context in diffs. Imports, type definitions, and other dependencies may exist outside the visible lines. However, you now have TOOLS to fetch additional context when needed.</partialContext>
     <goodThings>Call out notable positives to reinforce good practices.</goodThings>
-    <solution>Think about how you would have solved the problem. If it’s different, why is that? Does your code handle more (edge) cases? Is it shorter/easier/cleaner/faster/safer yet functionally equivalent? Is there some underlying pattern you spotted that isn’t captured by the current code?</solution>
+    <solution>Think about how you would have solved the problem. If it's different, why is that? Does your code handle more (edge) cases? Is it shorter/easier/cleaner/faster/safer yet functionally equivalent? Is there some underlying pattern you spotted that isn't captured by the current code?</solution>
     <abstractions>Do you see potential for useful abstractions? Partially duplicated code often indicates that a more abstract or general piece of functionality can be extracted and then reused in different contexts.<abstractions>
-    <DRY>Think about libraries or existing product code. When someone re-implements existing functionality, more often than not it’s simply because they don’t know it already exists. Sometimes, code or functionality is duplicated on purpose, e.g., in order to avoid dependencies. In such cases, a code comment can clarify the intent. Is the introduced functionality already provided by an existing library?<DRY>
+    <DRY>Think about libraries or existing product code. When someone re-implements existing functionality, more often than not it's simply because they don’t know it already exists. Sometimes, code or functionality is duplicated on purpose, e.g., in order to avoid dependencies. In such cases, a code comment can clarify the intent. Is the introduced functionality already provided by an existing library?<DRY>
     <legibility>Think about your reading experience. Did you grasp the concepts in a reasonable amount of time? Was the flow sane and were variable and methods names easy to follow? Were you able to keep track through multiple files or functions? Were you put off by inconsistent naming?</legibility>
   </coverageChecklist>
 
@@ -45,12 +45,27 @@ const DEFAULT_REVIEW_GUIDELINES = `
     <courtesy>Be kind, address code not people, explain *why*.</courtesy>
     <labels>
       <required>Must fix before approval.</required>
-      <nit>Minor polish; author may ignore.</nit>
+      <nit>
+        Minor polish; author may ignore.
+        <caveat>
+          Don't nit that much, use sparingly
+        </caveat>
+      </nit>
       <optional>Worth considering; not mandatory.</optional>
       <fyi>Informational for future work.</fyi>
-      <praise>Praise the author for good work.</praise>
+      <praise>
+        Praise the author for good work.
+        <caveat>
+          Only use this if the change is really good, it should be RARE
+        </caveat>
+      </praise>
     </labels>
-    <balance>Point out problems; offer guidance or sample code only when helpful. Reinforce positives, too, but don't overdo it. Regular code doesn't need praise.</balance>
+    <balance>
+      Optimise for *developer attention*:
+        • Focus on issues that block merging or will bite us later.  
+        • Skip advice that is purely preferential if the code already meets style/consistency rules.  
+        • Use the comment budget to decide whether to surface lower-severity notes.
+    </balance>
   </commentGuidelines>
 
   <!--  5. CL DESCRIPTION FEEDBACK  -->

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -76,6 +76,16 @@ export async function reviewChunkWithAgent(
         contextLines.push("    </risks>");
       }
 
+      if (hunkSummary.issues.length > 0) {
+        contextLines.push("    <issues>");
+        hunkSummary.issues.forEach((issue) => {
+          contextLines.push(
+            `      <issue severity="${escapeXml(issue.severity)}" kind="${escapeXml(issue.kind)}">${escapeXml(issue.description)}</issue>`,
+          );
+        });
+        contextLines.push("    </issues>");
+      }
+
       if (hunkSummary.tests.length > 0) {
         contextLines.push("    <suggestedTests>");
         hunkSummary.tests.forEach((test) => {

--- a/src/summary-agent-system-prompt.ts
+++ b/src/summary-agent-system-prompt.ts
@@ -71,6 +71,19 @@ export function getSummarySystemPrompt(): string {
       </decision>
     </globalChecklist>
 
+    <commentBudget>
+      You have a default budget of **15 comments total** per review:
+        • up to 15 **REQUIRED**  
+        • up to 3 **OPTIONAL**  
+        • up to 2 **NIT**  
+      Exceed the budget *only* if skipping a note would introduce a **correctness or security bug**.
+    </commentBudget>
+    <deduplicationRule>
+      Consolidate repeated findings:
+        • If the same issue occurs in multiple places, comment once and note “applies to X similar lines”.
+        • Prefer file-level or CL-level comments over many inline nits.
+    </deduplicationRule>
+
     <hunkChecklist>
       For every processable hunk, provide:
       <overview>1 - 2 sentences describing the local change in the context of the PR.</overview>
@@ -88,6 +101,28 @@ export function getSummarySystemPrompt(): string {
       Use markdown formatting for readability. This will replace any blank PR description.
     </prDescription>
   </additionalChecklist>
+    <!--  INPUT SHAPE  -->
+  <ingest>
+    You receive:
+      • the full unified diff
+      • zero or more previous CodePress comments
+      • **an array of <hunkResult> payloads** from the micro-reviewers (see schema below).
+    Parse those <hunkResult> blocks first; they contain all local findings.
+  </ingest>
+
+  <!--  PROMOTION & DEDUPLICATION RULES  -->
+  <promotionRules>
+    1. Merge issues with identical <kind> and same file *or* identical message text.
+    2. For each merged group decide the final severity:
+       • REQUIRED  - correctness, security, data loss, or fails agreed standards.
+       • OPTIONAL  - improves maintainability, clarity, perf; not a merge blocker.
+       • NIT       - purely stylistic or micro-optimisation.
+       • PRAISE    - exemplary practice; emit max one per PR.
+    3. Apply the comment budget (10 REQUIRED, 3 OPTIONAL, 2 NIT, 1 PRAISE).  
+       - If duplicates push a category over budget, keep the *most representative* item and drop the rest.
+    4. Store the chosen severity in each <issue> as <severity>.
+  </promotionRules>
+
   <!--  OUTPUT FORMAT (STRICT)  -->
   <responseFormat>
     <!-- ✦ Emit exactly ONE <global> block. -->
@@ -123,12 +158,15 @@ export function getSummarySystemPrompt(): string {
 
     <!-- ✦ Emit ONE <hunk> block for EVERY diff hunk, in original order, only if the hunk needs notes. If you think the code is good, just skip the hunk! -->
     <hunks>
+      <!-- The summariser must output deduped, severity-promoted issues -->
       <hunk index="0">
         <file>src/components/SEOHead.tsx</file>
         <overview>Makes <code>description</code> prop optional to support legacy pages.</overview>
-        <risks>
-          <item tag="SEO">Missing descriptions may hurt search ranking.</item>
-        </risks>
+        <issues>
+          <issue severity="OPTIONAL" kind="missing-meta-description">
+            Missing meta description may hurt SEO.
+          </issue>
+        </issues>
         <tests>
           <item>Render page without description and verify meta tags default correctly.</item>
         </tests>

--- a/src/summary-agent-system-prompt.ts
+++ b/src/summary-agent-system-prompt.ts
@@ -73,9 +73,10 @@ export function getSummarySystemPrompt(): string {
 
     <commentBudget>
       You have a default budget of **15 comments total** per review:
-        • up to 15 **REQUIRED**  
+        • up to 10 **REQUIRED**  
         • up to 3 **OPTIONAL**  
         • up to 2 **NIT**  
+        • up to 1 **PRAISE**
       Exceed the budget *only* if skipping a note would introduce a **correctness or security bug**.
     </commentBudget>
     <deduplicationRule>

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -14,15 +14,39 @@ const DEFAULT_SYSTEM_PROMPT = `
     <design>Evaluate overall architecture and interactions. Does the change belong here? Does it integrate cleanly?</design>
     <functionality>Confirm the CL does what the author intends and that this is valuable to users (end-users & future developers). Think about edge-cases, concurrency, user-visible behavior.</functionality>
     <complexity>Avoid unnecessary complexity or speculative over-engineering. Simpler is better.</complexity>
-    <tests>Are there adequate unit/integration/e2e tests? Do they fail on bugs and avoid false positives?</tests>
+    <tests>
+      Are there adequate unit/integration/e2e tests? Do they fail on bugs and avoid false positives?
+      <caveat>
+        If this update is on the frontend, we don't necessarily need to have tests for it.
+      </caveat>
+    </tests>
     <naming>Are identifiers clear, specific, and concise?</naming>
     <comments>Comments explain *why*, not just *what*. Remove stale TODOs, prefer clearer code over explanatory comments.</comments>
-    <style>Follow the project's official language style guide. Mark non-guide nits with the **Nit:** prefix.</style>
+    <style>
+      Follow the project's official language style guide.
+      Only flag **style nits** when they:
+      1. obscure correctness
+      2. are trivial to fix (≤2 lines)
+      3. you have not exceeded the *comment budget* (see below).
+    </style>
+
     <consistency>Stay consistent with existing code unless that code violates a higher rule (e.g., style guide).</consistency>
     <documentation>Update READMEs, reference docs, build/test/release instructions affected by the change.</documentation>
     <everyLine>Read every human-written line you're responsible for. Skim only generated or data blobs.</everyLine>
     <partialContext>CRITICAL: You only see partial file context in diffs. Imports, type definitions, and other dependencies may exist outside the visible lines. Do NOT suggest missing imports or dependencies unless you can clearly see they are absent from the provided context.</partialContext>
     <goodThings>Call out notable positives to reinforce good practices.</goodThings>
+    <commentBudget>
+      You have a default budget of **15 comments total** per review:
+        • up to 15 **REQUIRED**  
+        • up to 3 **OPTIONAL**  
+        • up to 2 **NIT**  
+      Exceed the budget *only* if skipping a note would introduce a **correctness or security bug**.
+    </commentBudget>
+    <deduplicationRule>
+      Consolidate repeated findings:
+        • If the same issue occurs in multiple places, comment once and note “applies to X similar lines”.
+        • Prefer file-level or CL-level comments over many inline nits.
+    </deduplicationRule>
   </coverageChecklist>
 
   <!--  3. REVIEW WORKFLOW - HOW TO NAVIGATE  -->
@@ -38,12 +62,27 @@ const DEFAULT_SYSTEM_PROMPT = `
     <courtesy>Be kind, address code not people, explain *why*.</courtesy>
     <labels>
       <required>Must fix before approval.</required>
-      <nit>Minor polish; author may ignore.</nit>
+      <nit>
+        Minor polish; author may ignore.
+        <caveat>
+          Don't nit that much, use sparingly
+        </caveat>
+      </nit>
       <optional>Worth considering; not mandatory.</optional>
       <fyi>Informational for future work.</fyi>
-      <praise>Praise the author for good work.</praise>
+      <praise>
+        Praise the author for good work.
+        <caveat>
+          Only use this if the change is really good, it should be RARE
+        </caveat>
+      </praise>
     </labels>
-    <balance>Point out problems; offer guidance or sample code only when helpful. Reinforce positives, too, but don't overdo it. Regular code doesn't need praise.</balance>
+    <balance>
+      Optimise for *developer attention*:
+        • Focus on issues that block merging or will bite us later.  
+        • Skip advice that is purely preferential if the code already meets style/consistency rules.  
+        • Use the comment budget to decide whether to surface lower-severity notes.
+    </balance>
   </commentGuidelines>
 
   <!--  5. CL DESCRIPTION FEEDBACK  -->

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,11 +60,18 @@ export interface RiskItem {
   description: string;
 }
 
+export interface IssueItem {
+  severity: string;
+  kind: string;
+  description: string;
+}
+
 export interface HunkSummary {
   index: number;
   file: string;
   overview: string;
-  risks: RiskItem[];
+  risks: RiskItem[]; // Keep for backward compatibility with keyRisks
+  issues: IssueItem[]; // New format for hunk-level issues
   tests: string[];
 }
 

--- a/test/ai-client.test.ts
+++ b/test/ai-client.test.ts
@@ -148,6 +148,7 @@ describe("AI Client", () => {
             file: "src/example.ts",
             overview: "Refactored return value and added new function",
             risks: [{ tag: "TEST", description: "Missing test coverage" }],
+            issues: [],
             tests: [
               "Should test newFunction return value",
               "Should test backward compatibility",
@@ -160,6 +161,7 @@ describe("AI Client", () => {
             risks: [
               { tag: "STYLE", description: "Minor documentation update" },
             ],
+            issues: [],
             tests: ["Verify documentation accuracy"],
           },
         ],
@@ -377,6 +379,7 @@ This PR introduces a new authentication service for user login and session manag
               { tag: "SEC", description: "Potential security flaw" },
               { tag: "TEST", description: "No tests for new auth flow" },
             ],
+            issues: [],
             tests: [
               "Test valid credentials",
               "Test invalid credentials",
@@ -388,6 +391,7 @@ This PR introduces a new authentication service for user login and session manag
             file: "src/utils.ts",
             overview: "Added utility functions",
             risks: [{ tag: "PERF", description: "May impact performance" }],
+            issues: [],
             tests: ["Test utility function outputs"],
           },
         ],
@@ -434,6 +438,7 @@ This PR introduces a new authentication service for user login and session manag
             file: "src/bug.ts",
             overview: "Fixed the bug",
             risks: [],
+            issues: [],
             tests: [],
           },
         ],

--- a/test/ai-client.test.ts
+++ b/test/ai-client.test.ts
@@ -757,5 +757,254 @@ This PR introduces a new authentication service for user login and session manag
         reasoning: "This should use fallback decision.",
       });
     });
+
+    it("should parse issues in hunks correctly", async () => {
+      const xmlWithIssues = `
+<prType>feature</prType>
+<overview>
+  <item>Added new authentication module</item>
+</overview>
+<keyRisks></keyRisks>
+<hunks>
+  <hunk index="0">
+    <file>src/auth.ts</file>
+    <overview>New authentication logic</overview>
+    <risks></risks>
+    <issues>
+      <issue severity="high" kind="security">SQL injection vulnerability in login query</issue>
+      <issue severity="medium" kind="performance">Inefficient password hashing algorithm</issue>
+      <issue severity="low" kind="style">Missing JSDoc comments on public methods</issue>
+    </issues>
+    <tests></tests>
+  </hunk>
+</hunks>`;
+
+      (generateText as jest.Mock).mockResolvedValue({
+        text: xmlWithIssues,
+      });
+
+      const result = await summarizeDiff(mockChunks, mockModelConfig);
+
+      expect(result.hunks).toHaveLength(1);
+      expect(result.hunks[0].issues).toEqual([
+        {
+          severity: "high",
+          kind: "security",
+          description: "SQL injection vulnerability in login query",
+        },
+        {
+          severity: "medium",
+          kind: "performance",
+          description: "Inefficient password hashing algorithm",
+        },
+        {
+          severity: "low",
+          kind: "style",
+          description: "Missing JSDoc comments on public methods",
+        },
+      ]);
+    });
+
+    it("should handle issues with missing attributes gracefully", async () => {
+      const xmlWithInvalidIssues = `
+<prType>feature</prType>
+<overview>
+  <item>Test summary</item>
+</overview>
+<keyRisks></keyRisks>
+<hunks>
+  <hunk index="0">
+    <file>src/test.ts</file>
+    <overview>Test overview</overview>
+    <risks></risks>
+    <issues>
+      <issue severity="high" kind="security">Valid issue with all attributes</issue>
+      <issue severity="medium">Missing kind attribute</issue>
+      <issue kind="performance">Missing severity attribute</issue>
+      <issue>Missing both severity and kind attributes</issue>
+    </issues>
+    <tests></tests>
+  </hunk>
+</hunks>`;
+
+      (generateText as jest.Mock).mockResolvedValue({
+        text: xmlWithInvalidIssues,
+      });
+
+      const result = await summarizeDiff(mockChunks, mockModelConfig);
+
+      expect(result.hunks).toHaveLength(1);
+      // Should only include the issue with all required attributes
+      expect(result.hunks[0].issues).toEqual([
+        {
+          severity: "high",
+          kind: "security",
+          description: "Valid issue with all attributes",
+        },
+      ]);
+    });
+
+    it("should handle multiple hunks with different issues", async () => {
+      const xmlWithMultipleHunksAndIssues = `
+<prType>refactor</prType>
+<overview>
+  <item>Refactored user management and database layer</item>
+</overview>
+<keyRisks></keyRisks>
+<hunks>
+  <hunk index="0">
+    <file>src/user.ts</file>
+    <overview>Refactored user validation</overview>
+    <risks></risks>
+    <issues>
+      <issue severity="critical" kind="security">Weak password validation allows dictionary attacks</issue>
+      <issue severity="high" kind="logic">Email validation regex doesn't handle edge cases</issue>
+    </issues>
+    <tests></tests>
+  </hunk>
+  <hunk index="1">
+    <file>src/database.ts</file>
+    <overview>Updated database connection handling</overview>
+    <risks></risks>
+    <issues>
+      <issue severity="medium" kind="performance">Connection pool size may be insufficient</issue>
+      <issue severity="low" kind="maintainability">Complex nested callbacks should use async/await</issue>
+    </issues>
+    <tests></tests>
+  </hunk>
+</hunks>`;
+
+      (generateText as jest.Mock).mockResolvedValue({
+        text: xmlWithMultipleHunksAndIssues,
+      });
+
+      const result = await summarizeDiff(mockChunks, mockModelConfig);
+
+      expect(result.hunks).toHaveLength(2);
+
+      expect(result.hunks[0].issues).toEqual([
+        {
+          severity: "critical",
+          kind: "security",
+          description: "Weak password validation allows dictionary attacks",
+        },
+        {
+          severity: "high",
+          kind: "logic",
+          description: "Email validation regex doesn't handle edge cases",
+        },
+      ]);
+
+      expect(result.hunks[1].issues).toEqual([
+        {
+          severity: "medium",
+          kind: "performance",
+          description: "Connection pool size may be insufficient",
+        },
+        {
+          severity: "low",
+          kind: "maintainability",
+          description: "Complex nested callbacks should use async/await",
+        },
+      ]);
+    });
+
+    it("should handle empty issues blocks", async () => {
+      const xmlWithEmptyIssues = `
+<prType>bugfix</prType>
+<overview>
+  <item>Fixed minor styling issue</item>
+</overview>
+<keyRisks></keyRisks>
+<hunks>
+  <hunk index="0">
+    <file>src/styles.css</file>
+    <overview>Updated margin values</overview>
+    <risks></risks>
+    <issues></issues>
+    <tests></tests>
+  </hunk>
+</hunks>`;
+
+      (generateText as jest.Mock).mockResolvedValue({
+        text: xmlWithEmptyIssues,
+      });
+
+      const result = await summarizeDiff(mockChunks, mockModelConfig);
+
+      expect(result.hunks).toHaveLength(1);
+      expect(result.hunks[0].issues).toEqual([]);
+    });
+
+    it("should handle hunks with both risks and issues", async () => {
+      const xmlWithBothRisksAndIssues = `
+<prType>feature</prType>
+<overview>
+  <item>Added payment processing module</item>
+</overview>
+<keyRisks></keyRisks>
+<hunks>
+  <hunk index="0">
+    <file>src/payment.ts</file>
+    <overview>New payment processing logic</overview>
+    <risks>
+      <item tag="SEC">Payment data handling needs security review</item>
+      <item tag="TEST">Missing integration tests for payment flows</item>
+    </risks>
+    <issues>
+      <issue severity="critical" kind="security">Credit card numbers stored in plain text</issue>
+      <issue severity="high" kind="compliance">PCI DSS compliance requirements not met</issue>
+      <issue severity="medium" kind="error-handling">Missing error handling for failed transactions</issue>
+    </issues>
+    <tests>
+      <item>Test successful payment processing</item>
+      <item>Test payment failure scenarios</item>
+    </tests>
+  </hunk>
+</hunks>`;
+
+      (generateText as jest.Mock).mockResolvedValue({
+        text: xmlWithBothRisksAndIssues,
+      });
+
+      const result = await summarizeDiff(mockChunks, mockModelConfig);
+
+      expect(result.hunks).toHaveLength(1);
+
+      // Verify both risks and issues are parsed correctly
+      expect(result.hunks[0].risks).toEqual([
+        {
+          tag: "SEC",
+          description: "Payment data handling needs security review",
+        },
+        {
+          tag: "TEST",
+          description: "Missing integration tests for payment flows",
+        },
+      ]);
+
+      expect(result.hunks[0].issues).toEqual([
+        {
+          severity: "critical",
+          kind: "security",
+          description: "Credit card numbers stored in plain text",
+        },
+        {
+          severity: "high",
+          kind: "compliance",
+          description: "PCI DSS compliance requirements not met",
+        },
+        {
+          severity: "medium",
+          kind: "error-handling",
+          description: "Missing error handling for failed transactions",
+        },
+      ]);
+
+      expect(result.hunks[0].tests).toEqual([
+        "Test successful payment processing",
+        "Test payment failure scenarios",
+      ]);
+    });
   });
 });


### PR DESCRIPTION
## Support Hunk-Level Issues in Summaries

This PR enhances the CL summariser to handle a new `<issues>` section in hunk summaries, improving granularity of feedback beyond risks/tests.

**Key Changes:**
- Agent and summary system prompts extended with comment budget, deduplication rules, and `caveat` notes for `nit`/`praise`.
- `ai-client` now emits `<issues>` blocks when serializing, and parses them into a new `IssueItem` array.
- Added `IssueItem` interface and updated test fixtures to include empty `issues` arrays.
- Sample XML in prompts updated to illustrate `<issues>` usage.

**Review Notes:**
- Verify backward compatibility with tools expecting only `<risks>`.
- Consider adding tests for parsing non-empty `<issues>` sections.