### PR TITLE
Better Github Comment Suggestions

### DIFF
--- a/FILE_STRUCTURE.md
+++ b/FILE_STRUCTURE.md
@@ -115,7 +115,6 @@ interface Finding {
   message: string; // Review message
   severity: string; // Severity level (required, optional, nit, fyi)
   suggestion?: string; // Optional code suggestion
-  code?: string; // Optional code snippet
 }
 ```
 

--- a/src/agent/agent-system-prompt.ts
+++ b/src/agent/agent-system-prompt.ts
@@ -174,7 +174,7 @@ export function getInteractiveSystemPrompt(): string {
       Your response should contain two main sections:
       1. <comments> - new review comments to post
         ✦ Preserve the order in which issues appear in the diff.
-        ✦ Omit <suggestion> and/or <code> if you have nothing useful to add.
+        ✦ Omit <suggestion> if you have nothing useful to add.
         ✦ If the comment already exists in the <existingCommentsContext>, do not post it again.
       2. <resolvedComments> - existing comments that are now resolved
 
@@ -206,21 +206,12 @@ export function getInteractiveSystemPrompt(): string {
           make the prop required and avoid missing-description bugs.
         </message>
 
-        <!-- OPTIONAL: concrete replacement or illustrative snippet        -->
+        <!-- OPTIONAL: We'll use this code block as a replacement for what is currently there. It uses 
+          Github's native code suggestion syntax, which a user can commit immediately. Therefore the code block generated
+          needs to be a 100% valid replacement for the current code that can be committed without modification. -->
         <suggestion>
-          +  description: string;
+          description: string;
         </suggestion>
-
-        <!-- OPTIONAL: side-by-side fix or longer example (use fenced code
-            so GitHub renders it nicely)                                  -->
-        <code>
-          \`\`\`tsx
-          interface SEOProps {
-            title: string;
-            description: string; // required for correct meta tags
-          }
-          \`\`\`
-        </code>
       </comment>
 
       <!-- repeat additional <comment> blocks as needed -->

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -130,7 +130,7 @@ export function getSystemPrompt(): string {
 
       ✦ DO NOT include any other top-level text.
       ✦ Preserve the order in which issues appear in the diff.
-      ✦ Omit <suggestion> and/or <code> if you have nothing useful to add.
+      ✦ Omit <suggestion> if you have nothing useful to add.
     -->
     <comment>
       <!-- how serious is the issue?
@@ -158,17 +158,6 @@ export function getSystemPrompt(): string {
       <suggestion>
         +  description: string;
       </suggestion>
-
-      <!-- OPTIONAL: side-by-side fix or longer example (use fenced code
-          so GitHub renders it nicely)                                  -->
-      <code>
-        \`\`\`tsx
-        interface SEOProps {
-          title: string;
-          description: string; // required for correct meta tags
-        }
-        \`\`\`
-      </code>
     </comment>
 
     <!-- repeat additional <comment> blocks as needed -->

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,6 @@ export interface Finding {
   message: string;
   severity?: string;
   suggestion?: string;
-  code?: string;
 }
 
 export interface ReviewConfig {

--- a/src/xml-parser.ts
+++ b/src/xml-parser.ts
@@ -38,7 +38,6 @@ export function parseAgentResponse(xmlText: string): AgentResponse {
       const suggestionMatch = commentContent.match(
         /<suggestion>([\s\S]*?)<\/suggestion>/s,
       );
-      const codeMatch = commentContent.match(/<code>([\s\S]*?)<\/code>/s);
 
       if (!fileMatch || !lineMatch || !messageMatch) {
         continue; // Skip incomplete comments
@@ -50,7 +49,6 @@ export function parseAgentResponse(xmlText: string): AgentResponse {
       const suggestion = suggestionMatch
         ? suggestionMatch[1].trim()
         : undefined;
-      const code = codeMatch ? codeMatch[1].trim() : undefined;
       let lineToMatch: string | undefined;
 
       // The line content is used for matching, we need to strip the diff marker.
@@ -72,7 +70,6 @@ export function parseAgentResponse(xmlText: string): AgentResponse {
         message: message,
         severity: severity,
         suggestion: suggestion,
-        code: code,
       });
     }
   }
@@ -138,7 +135,6 @@ export function parseAgentResponse(xmlText: string): AgentResponse {
       const suggestionMatch = commentContent.match(
         /<suggestion>([\s\S]*?)<\/suggestion>/s,
       );
-      const codeMatch = commentContent.match(/<code>([\s\S]*?)<\/code>/s);
 
       if (!fileMatch || !lineMatch || !messageMatch) {
         continue; // Skip incomplete comments
@@ -150,7 +146,6 @@ export function parseAgentResponse(xmlText: string): AgentResponse {
       const suggestion = suggestionMatch
         ? suggestionMatch[1].trim()
         : undefined;
-      const code = codeMatch ? codeMatch[1].trim() : undefined;
       let lineToMatch: string | undefined;
 
       // The line content is used for matching, we need to strip the diff marker.
@@ -172,7 +167,6 @@ export function parseAgentResponse(xmlText: string): AgentResponse {
         message: message,
         severity: severity,
         suggestion: suggestion,
-        code: code,
       });
     }
   }

--- a/types.ts
+++ b/types.ts
@@ -4,5 +4,4 @@ export interface Finding {
   message: string; // comment body (may include ```suggestion blocks)
   severity?: string;
   suggestion?: string;
-  code?: string;
 }


### PR DESCRIPTION
## Remove code snippet support from reviews

This PR removes the optional `code` property and `<code>` block support across type definitions, parsers, and documentation.

**Key Changes:**
- Deleted `code?: string` from type interfaces (`src/types.ts`, `types.ts`, `FILE_STRUCTURE.md`).
- Stripped out `<code>` parsing logic in `src/xml-parser.ts`.
- Cleaned up system prompt templates (`src/agent/agent-system-prompt.ts`, `src/system-prompt.ts`).
- Updated documentation in `FILE_STRUCTURE.md` accordingly.

**Review Notes:**
- Ensure no residual `<code>` references remain.
- Confirm existing tests for comment parsing still pass without <code> handling.